### PR TITLE
TB-111 Add support for authenticating flow engine against tablyx system

### DIFF
--- a/redash/handlers/authentication.py
+++ b/redash/handlers/authentication.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import abort, flash, redirect, render_template, request, url_for
+from flask import abort, flash, redirect, render_template, request, url_for, make_response
 
 from flask_login import current_user, login_required, login_user, logout_user
 from redash import __version__, limiter, models, settings
@@ -209,7 +209,9 @@ def login(org_slug=None):
             ):
                 remember = "remember" in request.form
                 login_user(user, remember=remember)
-                return redirect(next_path)
+                response = make_response(redirect(next_path))
+                response.set_cookie('api_key', user.api_key)
+                return response
             else:
                 flash("Wrong email or password.")
         except NoResultFound:
@@ -234,7 +236,9 @@ def login(org_slug=None):
 @routes.route(org_scoped_rule("/logout"))
 def logout(org_slug=None):
     logout_user()
-    return redirect(get_login_url(next=None))
+    response = make_response(redirect(get_login_url(next=None)))
+    response.delete_cookie("api_key")
+    return response
 
 
 def base_href():


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description
Tablyx is gonna be a federated provider. Tablyx sets the api_key in the cookies so the flow-design component is able to take it and send it in the header of each request, once the request reaches the flow engine, it checks if the api_key is correct against Tablyx (api/session)

## Related Tickets & Documents

![Arquitectura tesis-federated provider](https://user-images.githubusercontent.com/25591616/140767465-8ed11abb-ebd5-4d96-86ac-9e87f6e59f59.jpg)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
